### PR TITLE
feat(storage): cargar/guardar data.json + seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Python
+__pycache__/ 
+*.pyc
+
+# App
+app.log
+data.json
+.env

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,9 +1,9 @@
-# cli.py con login habilitado
 from __future__ import annotations
 from getpass import getpass
 
 from .logging_conf import logger
 from .auth import login
+from .storage import load_data, save_data, path_data_file
 
 def pause():
     input("\nPresiona ENTER para continuar...")
@@ -47,11 +47,15 @@ def main():
     header("Gestión de Micro-Eventos (CLI)")
     if not do_login():
         return
+    
+    eventos = load_data()
 
     while True:
         op = menu()
 
         if op == 9:
+            save_data(eventos)
+            print(f"Datos guardados en {path_data_file()}")
             print("¡Hasta luego!")
             break
         elif op == -1:

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import json, os
+from typing import List, Dict
+from .logging_conf import logger
+
+_DATA_FILE = "data.json"
+
+def path_data_file() -> str:
+    return os.path.abspath(_DATA_FILE)
+
+def load_data() -> List[Dict]:
+    if os.path.exists(_DATA_FILE):
+        with open(_DATA_FILE, "r", encoding="utf-8") as f:
+            eventos = json.load(f)
+        logger.info("Datos cargados desde %s", path_data_file())
+        return eventos
+
+    eventos = [
+        {
+            "nombre": "charla1",
+            "descripcion": "Descripción de la charla 1",
+            "fecha": "2025-02-20",
+            "categoria": "charlas",
+            "cupos": 30,
+            "cupos_max": 30,
+        },
+        {
+            "nombre": "charla2",
+            "descripcion": "Descripción de la charla 2",
+            "fecha": "2025-02-21",
+            "categoria": "charlas",
+            "cupos": 25,
+            "cupos_max": 25,
+        },
+    ]
+    logger.info("Datos de ejemplo cargados (no se encontró data.json)")
+    return eventos
+
+def save_data(eventos: List[Dict]):
+    with open(_DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(eventos, f, ensure_ascii=False, indent=2)
+    logger.info("Datos guardados en %s", path_data_file())


### PR DESCRIPTION
Se introdujo src/storage.py para gestionar la carga y el almacenamiento de datos de eventos en data.json. Se actualizó cli.py para usar estas funciones, lo que garantiza la persistencia de los datos de eventos entre sesiones. Se añadió .gitignore para excluir archivos comunes de Python y específicos de la aplicación.

Como pruebas, se validó que al ingresar la opción 9 se guardan los datos en la raíz del proyecto.

<img width="898" height="435" alt="image" src="https://github.com/user-attachments/assets/d7ad0726-fae8-406f-855a-18200563a62c" />
<img width="284" height="270" alt="image" src="https://github.com/user-attachments/assets/e4d8bcfe-98c7-49d4-a00b-d5d7233d3093" />
