### PR TITLE
feat(report): total, suma de cupos y agotados

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -6,6 +6,7 @@ from .auth import login
 from .storage import load_data, save_data, path_data_file
 from .events import listar_eventos, mostrar_evento, crear_evento_interactivo, editar_evento_interactivo, eliminar_evento_interactivo, buscar_interactivo
 from .sales import vender_interactivo, devolver_interactivo
+from .report import generar_reporte, imprimir_reporte
 
 def pause():
     input("\nPresiona ENTER para continuar...")
@@ -126,6 +127,12 @@ def main():
                 devolver_interactivo(eventos, idx)
             except (ValueError, IndexError):
                 print("Índice inválido.")
+            pause()
+
+        elif op == 8:
+            header("Reporte")
+            rep = generar_reporte(eventos)
+            imprimir_reporte(rep)
             pause()
 
         elif op == 9:

--- a/src/report.py
+++ b/src/report.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import List, Dict
+
+def generar_reporte(eventos: List[Dict]) -> Dict[str, int]:
+    total = len(eventos)
+    suma_cupos = sum(e["cupos"] for e in eventos)
+    agotados = sum(1 for e in eventos if e["cupos"] == 0)
+    return {"total_eventos": total, "suma_cupos": suma_cupos, "eventos_agotados": agotados}
+
+def imprimir_reporte(rep: Dict[str, int]):
+    print(f"Total de eventos: {rep['total_eventos']}")
+    print(f"Suma de cupos disponibles: {rep['suma_cupos']}")
+    print(f"Eventos agotados: {rep['eventos_agotados']}")


### PR DESCRIPTION
Se presenta un nuevo módulo de informes con funciones para generar e imprimir un resumen de eventos, incluyendo el total de eventos, los cupos disponibles y las entradas agotadas. Integra la función de informes en la CLI con una nueva opción de menú.

- Prueba (8) Generar Reporte: 
<img width="459" height="353" alt="image" src="https://github.com/user-attachments/assets/8f9b2b85-f3c1-4b3c-97b3-d9ce2126912b" />

Se creó un nuevo evento y se agotaron sus cupos para generar otro reporte

- Prueba (8) Generar Reporte con un evento agotado:
<img width="446" height="351" alt="image" src="https://github.com/user-attachments/assets/68e0239d-7ee6-4505-89b2-55d97441aad7" />

- Data durante estas pruebas:
<img width="463" height="527" alt="image" src="https://github.com/user-attachments/assets/5d534898-02a6-4fcd-b37e-22ff98b93bee" />
